### PR TITLE
get file suffix name by absolute path

### DIFF
--- a/include/Http/Http.cc
+++ b/include/Http/Http.cc
@@ -369,7 +369,7 @@ bool Http::serve_file(const string& path)
         string suffix;
         
         // get suffix name
-        string path = _http_request.get_path();
+        // string path = _http_request.get_path();
         int i = path.size() - 1;
         while (path[i] != '.' && path[i] != '/')
             i--;


### PR DESCRIPTION
访问 默认主页得到的get_request()的字符为/, 会导致content_type 应该没html 而为plain 会显示网页的源码 而不是主页的信息， 采用绝对路径可以防止这种情况，并且不会带来额外的开销
